### PR TITLE
fix: tsoncifg path mapping correctly

### DIFF
--- a/apps/backend/nest-cli.json
+++ b/apps/backend/nest-cli.json
@@ -1,4 +1,5 @@
 {
   "collection": "@nestjs/schematics",
-  "sourceRoot": "src"
+  "sourceRoot": "src",
+  "entryFile": "apps/backend/src/main"
 }

--- a/apps/backend/tsconfig.build.json
+++ b/apps/backend/tsconfig.build.json
@@ -1,10 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"],
-  "baseUrl": "..",
-  "paths": {
-    "@swapflow": [
-      "../../packages"
-    ],
-  }
+  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
 }

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -18,8 +18,8 @@
     "noFallthroughCasesInSwitch": false,
     "baseUrl": "..",
     "paths": {
-      "@swapflow": [
-        "../../packages"
+      "@swapflow/*": [
+        "../packages/*"
       ],
     }
   }


### PR DESCRIPTION
I had to also update the nest-cli.json to add an entryFile
property that tells Nest where to find the new `js` file
so it can auto start the server when running `yarn start:dev`